### PR TITLE
[Fix] 몬스터 슬롯 확률 버그 수정

### DIFF
--- a/Project.998S/Assets/Scripts/Character/Controller/EnemyController.cs
+++ b/Project.998S/Assets/Scripts/Character/Controller/EnemyController.cs
@@ -121,7 +121,7 @@ public class EnemyController : Controller
         UseSkill(character, skillDataEnum, isHighDamage);
 
         int damage = Define.Calculate.Damage(character.currentAttack.Value + SkillData.Damage, targetCharacter.currentDefense.Value, character.currentLuck.Value);
-        slotAccuracyDamage = Define.Calculate.Accuracy(damage, character.currentAccuracy.Value);
+        slotAccuracyDamage = Define.Calculate.Accuracy(damage, character.currentLuck.Value);
 
         // NOTE : PlayerActionPopup의 로직과 중복됨. 시간 없어서 일단 기존 코드 사용.
         Managers.Stage.turnCharacter.Value.currentSkill.Value = SkillData;

--- a/Project.998S/Assets/Scripts/Data/Util/Define.cs
+++ b/Project.998S/Assets/Scripts/Data/Util/Define.cs
@@ -94,19 +94,12 @@ public static class Define
         /// </summary>
         /// <param name="damage">데미지</param>
         /// <param name="accuracy">정확도</param>
-        public static List<Dictionary<bool, int>> Accuracy(int damage, int focus = 0, int accuracy = 0)
+        public static List<Dictionary<bool, int>> Accuracy(int damage, int accuracy = 0)
         {
             List<Dictionary<bool, int>> result = new List<Dictionary<bool, int>>();
 
             for (int index = 0; index < MAX_SLOT; ++index)
             {
-                if (index < focus)
-                {
-                    result.Add(ReturnDictionary(true, damage));
-
-                    continue;
-                }
-
                 bool isCheckChance = IsChance(accuracy);
 
                 if (isCheckChance)

--- a/Project.998S/Assets/Scripts/UI/Popup/EnemyActionPopup.cs
+++ b/Project.998S/Assets/Scripts/UI/Popup/EnemyActionPopup.cs
@@ -40,6 +40,7 @@ public class EnemyActionPopup : UIPopup
             ++index;
             yield return new WaitForSeconds(0.1f);
 
+            Debug.Log(isSuccessSlot);
             if (true == isSuccessSlot)
             {
                 GetImage(index).sprite = Managers.Resource.LoadSprite(string.Concat(data.Icon, Define.Keyword.SUCCESS));


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
---
- 몬스터 확률에 따른 스킬 슬롯 구현
> 기존 플레이어의 포커스 시스템 구현으로 인해
별도의 슬롯 시스템을 구현하였습니니다.
> 이제 몬스터 확률은 플레이어 확률과는 별개로 작동합니다
> 몬스터의 스킬 슬롯은 총 2가지 상태가 있으며 이는 성공과 실패로 작동합니다.

# 변경된 기능에 대한 설명
---

- 목록 1
> 몬스터 확률에 따른 스킬 슬롯 구현
확률 계산을 통해 스킬 슬롯 표기를 진행합니다.

# 시각 자료
---

# 관련 이슈
---
- [] #162 